### PR TITLE
検索文字と閉じるボタンに明示的にcolor: #FFFFFF を設定する

### DIFF
--- a/src/content/components/search-down.tsx
+++ b/src/content/components/search-down.tsx
@@ -119,6 +119,7 @@ export const SearchDropdown: FC<{ repo: Repository }> = ({ repo }) => {
                 style={{
                   paddingLeft: "32px",
                   fontSize: "14px",
+                  color: "#FFFFFF",
                 }}
               />
               <Search
@@ -132,7 +133,12 @@ export const SearchDropdown: FC<{ repo: Repository }> = ({ repo }) => {
                 }}
               />
             </div>
-            <Button onClick={toggleSearch} size="sm">
+            <Button onClick={toggleSearch}
+              size="sm"
+              style={{
+                color: "#FFFFFF",
+              }}
+            >
               閉じる
             </Button>
           </div>


### PR DESCRIPTION
githubのテーマがデフォルトのテーマ(Light default)だと、検索ボックスに文字を入力しても文字が見えなかったり、閉じるボタンが見えなかったりします。
![スクリーンショット 2024-12-24 15 55 59](https://github.com/user-attachments/assets/869c708c-033e-4119-9bc3-c8e000516242)

これは文字のcolorが外からわたってきたものを利用するためなので、明示的に #FFFFFF を指定して見やすくします。

変更後は以下のように表示されます。デフォルトのテーマ(Light default)およびダークテーマ(Dark default)で同じ表示になることを確認しました。

![スクリーンショット 2024-12-24 15 57 30](https://github.com/user-attachments/assets/b2459794-c351-4e2d-9be0-e8fbc6f0fcad)

