### PR TITLE
fix: fetch the default branch name

### DIFF
--- a/src/content/hooks/use-workflow-files.ts
+++ b/src/content/hooks/use-workflow-files.ts
@@ -22,7 +22,7 @@ export const useWorkflowFiles = (repo: Repository) => {
     if (workflowFilesState.status === "idle") {
       setWorkflowFilesState({ status: "loading" })
 
-      void fetchWorkflowFiles(repo, "main")
+      void fetchWorkflowFiles(repo, defaultBranch)
         .then((workflowFiles) => {
           setWorkflowFilesState({
             status: "loaded",


### PR DESCRIPTION
デフォルトブランチを main 固定せず、取得してきたものを参照するようにしました。

以下のリポジトリで動作確認しました

デフォルトブランチが `master`
https://github.com/kimuchanman/self-introduction/actions

デフォルトブランチが `main`
https://github.com/d-kimuson/github-actions-search/actions