### PR TITLE
fix: GitHub の tree-commit-info API レスポンス形式変更に対応する

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A Chrome extension that enhances GitHub's Actions tab with search and personal p
 
 ![github-actions-search](https://github.com/user-attachments/assets/9d9a0b5a-9e2f-4fd8-909d-5f9647f58716)
 
-
 This extension addresses two major pain points when working with repositories containing numerous workflows:
 
 1. the lack of search functionality in the Actions tab

--- a/src/content/initialize-app.tsx
+++ b/src/content/initialize-app.tsx
@@ -8,11 +8,13 @@ export const { initializeApp, cleanApp } = (() => {
 
   return {
     initializeApp: (repo: Repository): boolean => {
-      const sidebarElement = Array.from(document.querySelectorAll("h2")).find(
-        (elm) => elm.textContent === "Actions"
-      )?.parentElement?.parentElement
+      const sidebarElement = Array.from(
+        document.querySelectorAll("h2, h3")
+      ).find((elm) => elm.textContent?.trim() === "Actions")?.parentElement
+        ?.parentElement
 
       if (!sidebarElement) {
+        console.debug("[github-actions-search] sidebar not found")
         return false
       }
 

--- a/src/content/repository/workflow.ts
+++ b/src/content/repository/workflow.ts
@@ -1,7 +1,10 @@
 import * as v from "valibot"
 import type { Repository } from "@/schema/repository"
 
-const treeInfoSchema = v.record(v.string(), v.unknown())
+const treeInfoSchema = v.union([
+  v.object({ entries: v.record(v.string(), v.unknown()) }),
+  v.record(v.string(), v.unknown()),
+])
 
 export const fetchWorkflowFiles = async (
   repo: Repository,
@@ -19,7 +22,18 @@ export const fetchWorkflowFiles = async (
     }
   )
 
-  return await response
-    .json()
-    .then((data: unknown) => Object.keys(v.parse(treeInfoSchema, data)))
+  return await response.json().then((data: unknown) => {
+    const parsed = v.safeParse(treeInfoSchema, data)
+    if (!parsed.success) {
+      console.error(
+        "[github-actions-search] Failed to parse workflow files",
+        parsed.issues,
+        data
+      )
+      throw new Error("Failed to parse workflow files response")
+    }
+    const files =
+      "entries" in parsed.output ? parsed.output.entries : parsed.output
+    return Object.keys(files)
+  })
 }

--- a/src/content/repository/workflow.ts
+++ b/src/content/repository/workflow.ts
@@ -1,10 +1,10 @@
 import * as v from "valibot"
 import type { Repository } from "@/schema/repository"
 
-const treeInfoSchema = v.union([
-  v.object({ entries: v.record(v.string(), v.unknown()) }),
-  v.record(v.string(), v.unknown()),
-])
+const entriesWrappedSchema = v.object({
+  entries: v.record(v.string(), v.unknown()),
+})
+const flatSchema = v.record(v.string(), v.unknown())
 
 export const fetchWorkflowFiles = async (
   repo: Repository,
@@ -23,17 +23,20 @@ export const fetchWorkflowFiles = async (
   )
 
   return await response.json().then((data: unknown) => {
-    const parsed = v.safeParse(treeInfoSchema, data)
-    if (!parsed.success) {
+    const entriesResult = v.safeParse(entriesWrappedSchema, data)
+    if (entriesResult.success) {
+      return Object.keys(entriesResult.output.entries)
+    }
+
+    const flatResult = v.safeParse(flatSchema, data)
+    if (!flatResult.success) {
       console.error(
         "[github-actions-search] Failed to parse workflow files",
-        parsed.issues,
+        flatResult.issues,
         data
       )
       throw new Error("Failed to parse workflow files response")
     }
-    const files =
-      "entries" in parsed.output ? parsed.output.entries : parsed.output
-    return Object.keys(files)
+    return Object.keys(flatResult.output)
   })
 }


### PR DESCRIPTION
## 背景

GitHub の内部 API (`tree-commit-info`) のレスポンス形式が変更され、ワークフローファイル一覧の取得が壊れていた。

変更前のレスポンス:

```json
{ "ci.yml": { "oid": "..." }, "release.yml": { "oid": "..." } }
```

変更後のレスポンス:

```json
{ "entries": { "ci.yml": { "oid": "..." }, "release.yml": { "oid": "..." } } }
```

これにより `Object.keys(data)` が `["entries"]` のみを返し、検索ドロップダウンに "entries" と表示されるだけになっていた。

## 変更内容

- `workflow.ts`: `entries` キーの有無を判定し、新旧両フォーマットからファイル名を取得するよう修正
- `initialize-app.tsx`: DOM セレクタを `h2, h3` に拡張し、`textContent.trim()` で空白を吸収するよう堅牢化

## 注記

`tree-commit-info` は GitHub の非公開・未ドキュメントの内部 API であり、今回の変更も公式の告知なく静かに行われたもの。公式 Changelog や REST API のバージョニング対象外のため、今後も同様の破壊的変更が予告なく発生する可能性がある。